### PR TITLE
chore: increase range of Firebase versions we support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.2.3
 
 - Increase minimally supported Dart version to 3.4.0 and Flutter to 3.22.0 (which was always the case anyway)
+- Increase maximum supported firebase_core to include 3.x.x
+- Increase maximum supported cloud_firestore to include 5.x.x
 
 ## 2.2.2
 - Add workflow for publishing to forgejo

--- a/packages/flutter_rbac_service_firebase/pubspec.yaml
+++ b/packages/flutter_rbac_service_firebase/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  cloud_firestore: ^4.5.0
-  firebase_core: ^2.9.0
+  cloud_firestore: ">=4.5.0 <6.0.0"
+  firebase_core: ">=2.9.0 <4.0.0"
   flutter:
     sdk: flutter
   flutter_rbac_service_data_interface:


### PR DESCRIPTION
The API we use hasn't changed so far.