### PR TITLE
chore: add missing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ From here the following methods can be called from this service to set up and us
 - getAccountGroupById(String accountGroupId): Retrieves an account group by its ID.
 - getAccountGroupByName(String accountGroupName): Retrieves an account group by its name.
 - getAllAccountGroups(): Retrieves all account groups.
+- getAccountGroupsByAccountIds(List<String> accountIds): Retrieves all account groups for the given account IDs.
 - updateAccountGroup(String accountGroupId, {String? newName, Set<String>? accountIds}): Updates an existing account group.
 - deleteAccountGroup(String accountGroupId): Deletes an account group.
 - addAccountsToAccountGroup(String accountgroupId, List<String> accountIds): Adds accounts to an account group.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ From here the following methods can be called from this service to set up and us
 - deleteAccountGroup(String accountGroupId): Deletes an account group.
 - addAccountsToAccountGroup(String accountgroupId, List<String> accountIds): Adds accounts to an account group.
 - removeAccountsFromAccountsGroup(String accountGroupId, List<String> accountIds): Removes accounts from an account group.
+- getGroupChangesForAccount(String accountId): Returns a stream that updates every time a group membership for the account ID changes.
+- getGroupChanges(): Returns a stream that updates every time a group membership changes.
 
 ### Permissions
 - createPermission(String name): Creates a new permission with the specified name.

--- a/packages/flutter_rbac_service/lib/src/services/rbac_service.dart
+++ b/packages/flutter_rbac_service/lib/src/services/rbac_service.dart
@@ -269,6 +269,10 @@ class RbacService {
   ) async =>
       _dataInterface.getAccountGroupByName(accountGroupName);
 
+  /// Retrieves the account groups that the given account IDs are a part of.
+  ///
+  /// Returns a [Future] that completes with the list of retrieved
+  /// [AccountGroupModel]s. The list will be empty if no groups are found.
   Future<List<AccountGroupModel>> getAccountGroupsByAccountIds(
     List<String> accountIds,
   ) async =>


### PR DESCRIPTION
We should really replace this README API thing for an auto-generated Sphinx like thing. Ideally like other Dart packages do it, for example https://pub.dev/documentation/riverpod/latest/